### PR TITLE
Integrators 2

### DIFF
--- a/qutip/core/data/dense.pxd
+++ b/qutip/core/data/dense.pxd
@@ -7,7 +7,7 @@ from .csr cimport CSR
 
 cdef class Dense(base.Data):
     cdef double complex *data
-    cdef bint fortran
+    cdef readonly bint fortran
     cdef object _np
     cdef bint _deallocate
     cdef void _fix_flags(Dense self, object array, bint make_owner=*)

--- a/qutip/solver/__init__.py
+++ b/qutip/solver/__init__.py
@@ -1,2 +1,4 @@
 from .result import *
 from .options import *
+from .integrator import *
+from .ode import *

--- a/qutip/solver/integrator.py
+++ b/qutip/solver/integrator.py
@@ -1,0 +1,415 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, Paul D. Nation and Robert J. Johansson.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+""" Define `Integrator`: ODE solver wrapper to use in qutip's Solver """
+
+
+__all__ = ['Integrator', 'integrator_collection', 'IntegratorException']
+
+
+from itertools import product
+from .options import SolverOdeOptions
+from qutip import QobjEvo, qeye, basis
+from functools import partial
+
+
+class IntegratorException(Exception):
+    pass
+
+
+class Integrator:
+    """
+    A wrapper around ODE solvers.
+    It ensure a common interface for Solver usage.
+    It takes and return states as :class:`qutip.core.data.Data`, it may return
+    a different data-type than the input type.
+
+    Parameters
+    ----------
+    sytem: qutip.QobjEvo
+        Quantum system in which states evolve.
+
+    options: qutip.SolverOptions
+        Options for the solver.
+    """
+    used_options = []
+    description = ""
+
+    def __init__(self, system, options):
+        self.system = system
+        self._stats = {}
+        self.options = options
+        self._prepare()
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        raise NotImplementedError
+
+    def set_state(self, t, state0):
+        """
+        Set the state of the ODE solver.
+
+        Parameters
+        ----------
+        t : float
+            Initial time
+
+        state0 : qutip.Data
+            Initial state.
+        """
+        raise NotImplementedError
+
+    def integrate(self, t, step=False, copy=True):
+        """
+        Evolve to t.
+
+        If `step` advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time with subsequent calls.
+
+        Before calling `integrate` for the first time, the initial step should
+        be set with `set_state`.
+
+        Parameters
+        ----------
+        t : float
+            Time to integrate to, should be larger than the previous time. If
+            the last integrate call was use with ``step=True``, the time can be
+            between the time at the start of the last call and now.
+
+        step : bool [False]
+            When True, integrate for a one internal step of the ODE solver.
+
+        copy : bool [True]
+            Whether to return a copy of the state or the state itself.
+
+        Return
+        ------
+        (t, state) : (float, qutip.Data)
+            The state of the solver at ``t``. The returned this can differ from
+            the input time only when ``step=True``.
+        """
+        raise NotImplementedError
+
+    def get_state(self, copy=True):
+        """
+        Obtain the state of the solver as a pair (t, state).
+
+        Return
+        ------
+        (t, state) : (float, qutip.Data)
+            The state of the solver at ``t``.
+        """
+        raise NotImplementedError
+
+    def run(self, tlist):
+        """
+        Integrate the system yielding the state for each times in tlist.
+
+        Parameters
+        ----------
+        tlist : *list* / *array*
+            List of times to yield the state.
+
+        Yield
+        -----
+        (t, state) : (float, qutip.Data)
+            The state of the solver at each ``t`` of tlist.
+        """
+        for t in tlist[1:]:
+            yield self.integrate(t, False)
+
+    def reset(self):
+        """Reset internal state of the ODE solver."""
+        self.set_state(*self.get_state)
+
+    def update_args(self, args):
+        """
+        Change the argument of the system.
+        Reset the ODE solver to ensure numerical validity.
+
+        Parameters
+        ----------
+        args : dict
+            New arguments
+        """
+        self.system.arguments(args)
+        self.reset()
+
+
+class _IntegratorCollection:
+    """
+    Collection of ODE :obj:`Integrator` available to Qutip's solvers.
+
+    :obj:`Integrator` are composed of 2 parts: `method` and `rhs`:
+    `method` are ODE integration method such as Runge-Kutta or Adams–Moulton.
+    `rhs` are options to control the :obj:`QobjEvo`'s matmul function.
+
+    Parameters
+    ----------
+    known_solvers : list of str
+        list of solver using this ensemble of integrator
+
+    options_class : :func:optionsclass decorated class
+        Option object to add integrator's option to the accepted keys.
+    """
+    def __init__(self, known_solvers, options_class):
+        self.known_solvers = known_solvers
+        self.options_class = options_class
+        # map from method key to integrator
+        self.method2integrator = {}
+        # map from rhs key to rhs function
+        self.rhs2system = {}
+        # methods's keys which support alternative rhs
+        self.base_methods = []
+        # Information about methods
+        self.method_data = {}
+        # Information about rhs
+        self.rhs_data = {}
+
+    def add_method(self, integrator, keys, solver,
+                   use_QobjEvo_matmul, time_dependent):
+        """
+        Add a new integrator to the set available to solvers.
+
+        Parameters
+        ----------
+
+        integrator : class derived from :obj:`Integrator`
+            New integrator to add.
+
+        keys : list of str
+            List of keys supported by the integrator.
+            When `options["methods"] in keys`, this integrator will be used.
+
+        solver : list of str
+            List of the [...]solve function that are supported by the
+            integrator.
+
+        use_QobjEvo_matmul : bool
+            Whether the Integrator use `QobjEvo.matmul` as the function of the
+            ODE. When `False`, rhs cannot be used.
+
+        time_dependent : bool
+            Whether integrator support time-dependent system.
+        """
+        if not isinstance(keys, list):
+            keys = [keys]
+        for key in keys:
+            if key in self.method2integrator:
+                raise ValueError("method '{}' already used".format(key))
+
+        integrator_data = self._complete_data(integrator, solver,
+                                              use_QobjEvo_matmul,
+                                              time_dependent)
+        for key in keys:
+            self.method2integrator[key] = integrator
+            self.method_data[key] = integrator_data
+        if use_QobjEvo_matmul:
+            self.base_methods += keys
+
+    def add_rhs(self, integrator, keys, solver, time_dependent):
+        """
+        Add a new rhs to the set available to solvers.
+
+        Parameters
+        ----------
+
+        integrator : callable
+            Function with the signature::
+
+                rhs(
+                    integrator: class,
+                    system: QobjEvo,
+                    options: SolverOptions
+                ) -> Integrator
+
+            that create the :obj:`Integrator` instance. The integrator can be
+            any integrator registered that has `"use_QobjEvo_matmul" == True`.
+            `system` is the :obj:`QobjEvo` driving the ODE: 'L', '-i*H', etc.
+            `options` is the :obj:`SolverOptions` of the solver.
+
+        keys : list of str
+            List of keys supported by the integrator.
+            When `options["methods"] in keys`, this integrator will be used.
+
+        solver : list of str
+            List of the [...]solve function that are supported by the
+            integrator.
+
+        time_dependent : bool
+            True if the integrator can solve time dependent systems.
+        """
+        if not isinstance(keys, list):
+            keys = [keys]
+        for key in keys:
+            if key in self.rhs2system:
+                raise ValueError("rhs keyword '{}' already used")
+        integrator_data = self._complete_data(integrator, solver,
+                                              True,
+                                              time_dependent)
+        for key in keys:
+            self.rhs2system[key] = integrator
+            self.rhs_data[key] = integrator_data
+
+    def _complete_data(self, integrator, solver, use_QobjEvo_matmul, td):
+        """
+        Get the information for the integrator.
+        """
+        integrator_data = {
+            "integrator": integrator,
+            "description": "",
+            # options used by the integrator, to add to the accepted option
+            # by the SolverOptions object.
+            "options": [],
+            # list of supported solver, sesolve, mesolve, etc.
+            "solver": [],
+            # The `method` use QobjEvo's matmul.
+            # If False, refuse `rhs` option.
+            "use_QobjEvo_matmul": use_QobjEvo_matmul,
+            # Support of time-dependent system
+            "time_dependent": td,
+        }
+        for sol in solver:
+            if sol not in self.known_solvers:
+                raise ValueError(f"Unknown solver '{sol}', known solver are"
+                                 + str(self.known_solvers))
+            integrator_data["solver"].append(sol)
+
+        if hasattr(integrator, 'description'):
+            integrator_data['description'] = integrator.description
+
+        if hasattr(integrator, 'used_options'):
+            integrator_data['options'] = integrator.used_options
+            for opt in integrator.used_options:
+                self.options_class.extra_options.add(opt)
+
+        return integrator_data
+
+    def __getitem__(self, key):
+        """
+        Obtain the integrator from the (method, rhs) key pair.
+        """
+        method, rhs = key
+        try:
+            integrator = self.method2integrator[method]
+        except KeyError:
+            raise KeyError(f"ode method {method} not found")
+        if rhs == "":
+            build_func = prepare_integrator
+        elif self.method_data[method]["use_QobjEvo_matmul"]:
+            try:
+                build_func = self.rhs2system[rhs]
+            except KeyError:
+                raise KeyError(f"ode rhs {rhs} not found")
+        else:
+            raise KeyError(f"ode method {method} does not support rhs")
+        return partial(build_func, integrator)
+
+    def _list_keys(self, keytype="methods", solver="",
+                   use_QobjEvo_matmul=None, time_dependent=None):
+        """
+        List integrators available corresponding to the conditions given.
+        Used in test.
+        """
+        if keytype == "methods":
+            names = [method for method in self.method2integrator
+                     if self._check_condition(method, "", solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+        elif keytype == "rhs":
+            names = [rhs for rhs in self.rhs2system
+                     if self._check_condition("", rhs, solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+        elif keytype == "pairs":
+            names = [(method, "") for method in self.method2integrator
+                     if self._check_condition(method, "", solver,
+                                             use_QobjEvo_matmul,
+                                             time_dependent)]
+            names += [(method, rhs)
+                for method, rhs in product(self.base_methods, self.rhs2system)
+                if rhs and self._check_condition(method, rhs, solver,
+                    use_QobjEvo_matmul, time_dependent)
+            ]
+        else:
+            raise ValueError("keytype must be one of "
+                             "'rhs', 'methods' or 'pairs'")
+        return names
+
+    def _check_condition(self, method, rhs, solver="",
+                         use_QobjEvo_matmul=None, time_dependent=None):
+        """
+        Verify if the pair (method, rhs) can be used for the given solver
+        and whether it support the desired capacities.
+        """
+        if method in self.method_data:
+            data = self.method_data[method]
+            if solver and solver not in data['solver']:
+                return False
+            if (
+                use_QobjEvo_matmul is not None and
+                use_QobjEvo_matmul != data['use_QobjEvo_matmul']
+            ):
+                return False
+            if (
+                time_dependent is not None and
+                time_dependent != data['time_dependent']
+            ):
+                return False
+
+        if rhs in self.rhs_data:
+            data = self.rhs_data[rhs]
+            if solver and solver not in data['solver']:
+                return False
+            if (
+                time_dependent is not None and
+                time_dependent != data['time_dependent']
+            ):
+                return False
+
+        return True
+
+
+integrator_collection = _IntegratorCollection(
+    ['sesolve', 'mesolve', 'mcsolve'],
+    SolverOdeOptions
+)
+
+def prepare_integrator(integrator, system, options):
+    """Default rhs function"""
+    return integrator(system, options)
+
+integrator_collection.add_rhs(prepare_integrator, "",
+                              ['sesolve', 'mesolve', 'mcsolve'], True)

--- a/qutip/solver/ode/__init__.py
+++ b/qutip/solver/ode/__init__.py
@@ -1,0 +1,1 @@
+from . scipy_integrator import *

--- a/qutip/solver/ode/scipy_integrator.py
+++ b/qutip/solver/ode/scipy_integrator.py
@@ -1,0 +1,320 @@
+"""ODE integrator from scipy."""
+
+__all__ = ['IntegratorScipyZvode', 'IntegratorScipyDop853',
+           'IntegratorScipylsoda']
+
+import numpy as np
+from scipy.integrate import ode
+from qutip.core import data as _data
+from qutip.core.data.reshape import column_unstack_dense, column_stack_dense
+from ..integrator import integrator_collection, IntegratorException, Integrator
+import warnings
+
+
+class IntegratorScipyZvode(Integrator):
+    """
+    Integrator using Scipy `ode` with zvode integrator. Ordinary Differential
+    Equation solver by netlib (http://www.netlib.org/odepack). Support 'Adams'
+    and 'BDF' methods for non-stiff and stiff systems respectively.
+    """
+    used_options = ['atol', 'rtol', 'nsteps', 'method', 'order',
+                    'first_step', 'max_step', 'min_step']
+    description = "scipy.integrate.ode using zvode integrator"
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('zvode', **opt)
+        self.name = "scipy zvode " + opt["method"]
+
+    def _mul_np_vec(self, t, vec):
+        """
+        Interface between scipy which use numpy and the driver, which use data.
+        """
+        state = _data.dense.fast_from_numpy(vec)
+        column_unstack_dense(state, self._size, inplace=True)
+        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
+        out = self.system.matmul_data(t, state, out)
+        column_stack_dense(out, inplace=True)
+        return out.as_ndarray().ravel()
+
+    def set_state(self, t, state0):
+        self._mat_state = state0.shape[1] > 1
+        self._size = state0.shape[0]
+        self._ode_solver.set_initial_value(
+            _data.column_stack(state0).to_array().ravel(),
+            t
+        )
+
+    def get_state(self, copy=True):
+        t = self._ode_solver.t
+        if self._mat_state:
+            state = _data.column_unstack_dense(
+                _data.dense.Dense(self._ode_solver._y, copy=False),
+                self._size,
+                inplace=True)
+        else:
+            state = _data.dense.Dense(self._ode_solver._y, copy=False)
+        return t, state.copy() if copy else state
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            self._one_step(t)
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+        elif self._ode_solver.t > t:
+            self._backstep(t)
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def _one_step(self, t):
+        """
+        Advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time using `backstep`.
+        """
+        # integrate(t, step=True) ignore the time and advance one step.
+        # Here we want to advance up to t doing maximum one step.
+        # So we check if a new step is really needed.
+        self.back = self.get_state(copy=True)
+        t_front = self._ode_solver._integrator.rwork[12]
+        t_ode = self._ode_solver.t
+        if t > t_front and t_ode >= t_front:
+            # The state is at t_front, do a step
+            self._ode_solver.integrate(t, step=True)
+            t_front = self._ode_solver._integrator.rwork[12]
+        elif t > t_front:
+            # The state is at a time before t_front, advance to t_front
+            t = t_front
+        else:
+            # t is inside the already computed integration range.
+            pass
+        if t_front >= t:
+            self._ode_solver.integrate(t)
+
+    def _backstep(self, t):
+        """
+        Retreive the state at time t, with t smaller than present ODE time.
+        The time t will always be between the last calls of `one_step`.
+        return the pair t, state.
+        """
+        # zvode can integrate with time lower than the most recent time
+        # but not over all the step interval.
+        # About 90% of the last step interval?
+        # Scipy raise a warning, not an Error.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self._ode_solver.integrate(t)
+        if not self._ode_solver.successful():
+            self.set_state(*self.back)
+            self._ode_solver.integrate(t)
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: 'Excess work done on this call. Try to increasing '
+                'the nsteps parameter in the Options class',
+            -2: 'Excess accuracy requested. (Tolerances too small.)',
+            -3: 'Illegal input detected.',
+            -4: 'Repeated error test failures. (Check all input.)',
+            -5: 'Repeated convergence failures. (Perhaps bad'
+                ' Jacobian supplied or wrong choice of MF or tolerances.)',
+            -6: 'Error weight became zero during problem. (Solution'
+                ' component i vanished, and ATOL or ATOL(i) = 0.)'
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+class IntegratorScipyDop853(Integrator):
+    """
+    Integrator using Scipy `ode` with dop853 integrator. Eight order
+    runge-kutta method by Dormand & Prince. Use fortran implementation
+    from [E. Hairer, S.P. Norsett and G. Wanner, Solving Ordinary Differential
+    Equations i. Nonstiff Problems. 2nd edition. Springer Series in
+    Computational Mathematics, Springer-Verlag (1993)].
+    """
+    description = "scipy.integrate.ode using dop853 integrator"
+    used_options = ['atol', 'rtol', 'nsteps', 'first_step', 'max_step',
+                    'ifactor', 'dfactor', 'beta']
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('dop853', **opt)
+        self.name = "scipy ode dop853"
+
+    def _mul_np_vec(self, t, vec):
+        """
+        Interface between scipy which use numpy and the driver, which use data.
+        """
+        state = _data.dense.fast_from_numpy(vec.view(np.complex128))
+        column_unstack_dense(state, self._size, inplace=True)
+        out = _data.dense.zeros(state.shape[0], state.shape[1], state.fortran)
+        out = self.system.matmul_data(t, state, out)
+        column_stack_dense(out, inplace=True)
+        return out.as_ndarray().ravel().view(np.float64)
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            # Scipy's DOP853 does not have a step function.
+            # It has a safe step lengh, but can be 0 if unknown.
+            dt = self._ode_solver._integrator.work[6]
+            if dt:
+                t = min(self._ode_solver.t + dt, t)
+
+        if self._ode_solver.t > t:
+            # While DOP853 support changing the direction of the integration,
+            # it does not do so efficiently. We do it manually.
+            self._ode_solver._integrator.work[6] *= -1
+            self._ode_solver.integrate(t)
+            self._ode_solver._integrator.work[6] *= -1
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def get_state(self, copy=True):
+        t = self._ode_solver.t
+        if self._mat_state:
+            state = _data.column_unstack_dense(
+                _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                  copy=False),
+                self._size,
+                inplace=True)
+        else:
+            state = _data.dense.Dense(self._ode_solver._y.view(np.complex128),
+                                      copy=False)
+        return t, state.copy() if copy else state
+
+    def set_state(self, t, state0):
+        self._mat_state = state0.shape[1] > 1
+        self._size = state0.shape[0]
+        self._ode_solver.set_initial_value(
+            _data.column_stack(state0).to_array().ravel().view(np.float64),
+            t
+        )
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: 'input is not consistent',
+            -2: 'larger nsteps is needed, Try to increase the nsteps '
+                'parameter in the Options class.',
+            -3: 'step size becomes too small. Try increasing tolerance',
+            -4: 'problem is probably stiff (interrupted), try "bdf" '
+                'method instead',
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+class IntegratorScipylsoda(IntegratorScipyDop853):
+    """
+    Integrator using Scipy `ode` with lsoda integrator. ODE solver by netlib
+    (http://www.netlib.org/odepack) Automatically choose between 'Adams' and
+    'BDF' methods to solve both stiff and non-stiff systems.
+    """
+    used_options = ['atol', 'rtol', 'nsteps', 'max_order_ns', 'max_order_s',
+                    'first_step', 'max_step', 'min_step']
+    description = "scipy.integrate.ode using lsoda integrator"
+
+    def _prepare(self):
+        """
+        Initialize the solver
+        """
+        self._ode_solver = ode(self._mul_np_vec)
+        opt = {key: self.options.ode[key]
+               for key in self.used_options
+               if key in self.options.ode}
+        self._ode_solver.set_integrator('lsoda', **opt)
+        self.name = "scipy lsoda"
+
+    def integrate(self, t, step=False, copy=True):
+        if step:
+            self._one_step(t)
+        elif self._ode_solver.t < t:
+            self._ode_solver.integrate(t)
+        elif self._ode_solver.t > t:
+            self._backstep(t)
+        self._check_failed_integration()
+        return self.get_state(copy)
+
+    def _one_step(self, t):
+        """
+        Advance up to t by one internal solver step.
+        Should be able to retreive the state at any time between the present
+        time and the resulting time using `backstep`.
+        """
+        # integrate(t, step=True) ignore the time and advance one step.
+        # Here we want to advance up to t doing maximum one step.
+        # So we check if a new step is really needed.
+        self.back = self.get_state(copy=True)
+        t_front = self._ode_solver._integrator.rwork[12]
+        t_ode = self._ode_solver.t
+        if t > t_front and t_ode >= t_front:
+            # The state is at t_front, do a step
+            self._ode_solver.integrate(t, step=True)
+            t_front = self._ode_solver._integrator.rwork[12]
+        elif t > t_front:
+            # The state is at a time before t_front, advance to t_front
+            t = t_front
+        else:
+            # t is inside the already computed integration range.
+            pass
+        if t_front >= t:
+            self._ode_solver.integrate(t)
+
+    def _backstep(self, t):
+        """
+        Retreive the state at time t, with t smaller than present ODE time.
+        The time t will always be between the last calls of `one_step`.
+        return the pair t, state.
+        """
+        # like zvode, lsoda can step with time lower than the most recent.
+        # But not all the step interval.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self._ode_solver.integrate(t)
+        if not self._ode_solver.successful():
+            self.set_state(*self.back)
+            self._ode_solver.integrate(t)
+
+    def _check_failed_integration(self):
+        if self._ode_solver.successful():
+            return
+        messages = {
+            -1: "Excess work done on this call."
+                "Try to increase the nsteps parameter in the Options class.",
+            -2: "Excess accuracy requested (tolerances too small).",
+            -3: "Illegal input detected (internal error).",
+            -4: "Repeated error test failures (internal error).",
+            -5: "Repeated convergence failures (perhaps bad Jacobian or tolerances).",
+            -6: "Error weight became zero during problem.",
+            -7: "Internal workspace insufficient to finish (internal error)."
+        }
+        raise IntegratorException(messages[self._ode_solver._integrator.istate])
+
+
+integrator_collection.add_method(IntegratorScipyZvode, keys=['adams', 'bdf'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)
+
+integrator_collection.add_method(IntegratorScipyDop853, keys=['dop853'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)
+
+integrator_collection.add_method(IntegratorScipylsoda, keys=['lsoda'],
+                                 solver=['sesolve', 'mesolve', 'mcsolve'],
+                                 use_QobjEvo_matmul=True, time_dependent=True)

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,0 +1,120 @@
+from qutip.solver.integrator import *
+from qutip.solver.options import SolverOptions
+from qutip.core import QobjEvo, liouvillian
+import qutip as qt
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+
+def id_from_keys(keys):
+    if keys[1] == "":
+        return keys[0]
+    else:
+        return keys[0] + "_" + keys[1]
+
+
+class TestIntegratorCte():
+    _analytical_se = lambda _, t: np.cos(t * np.pi)
+    se_system = QobjEvo(-1j * qt.sigmax() * np.pi)
+    _analytical_me = lambda _, t: 1 - np.exp(-t)
+    me_system = liouvillian(QobjEvo(qt.qeye(2)), c_ops=[qt.destroy(2)])
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="sesolve"),
+        ids=id_from_keys
+    )
+    def se_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mesolve"),
+        ids=id_from_keys
+    )
+    def me_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mcsolve"),
+        ids=id_from_keys
+    )
+    def mc_keys(self, request):
+        return request.param
+
+    def test_se_integration(self, se_keys):
+        method, rhs = se_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.se_system, opt)
+        state0 = qt.core.unstack_columns(qt.basis(6,0).data, (2, 3))
+        evol.set_state(0, state0)
+        for t, state in evol.run(np.linspace(0, 2, 21)):
+            assert_allclose(self._analytical_se(t),
+                            state.to_array()[0, 0], atol=2e-5)
+            assert state.shape == (2, 3)
+
+    def test_me_integration(self, me_keys):
+        method, rhs = me_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.me_system, opt)
+        state0 = qt.operator_to_vector(qt.fock_dm(2,1)).data
+        evol.set_state(0, state0)
+        for t in np.linspace(0, 2, 21):
+            t_, state = evol.integrate(t)
+            assert t_ == t
+            assert_allclose(self._analytical_me(t),
+                            state.to_array()[0, 0], atol=2e-5)
+
+    def test_mc_integration(self, mc_keys):
+        method, rhs = mc_keys
+        opt = SolverOptions(method=method, rhs=rhs)
+        evol = integrator_collection[method, rhs](self.se_system, opt)
+        state = qt.basis(2,0).data
+        evol.set_state(0, state)
+        t = 0
+        for i in range(1, 21):
+            t_target = i * 0.05
+            while t < t_target:
+                t_old, y_old = evol.get_state()
+                t, state = evol.integrate(t_target, step=True)
+                assert t <= t_target
+                assert t > t_old
+                assert_allclose(self._analytical_se(t),
+                                state.to_array()[0, 0], atol=2e-5)
+                t_back = (t + t_old) / 2
+                t_got, bstate = evol.integrate(t_back)
+                assert t_back == t_got
+                assert_allclose(self._analytical_se(t),
+                                state.to_array()[0, 0], atol=2e-5)
+                t, state = evol.integrate(t)
+
+
+class TestIntegrator(TestIntegratorCte):
+    _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
+    se_system = QobjEvo([-1j * qt.sigmax() * np.pi, "t"])
+    _analytical_me = lambda _, t: 1 - np.exp(-(t**3) / 3)
+    me_system = liouvillian(QobjEvo(qt.qeye(2)),
+                            c_ops=[QobjEvo([qt.destroy(2), 't'])])
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="sesolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def se_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mesolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def me_keys(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=integrator_collection._list_keys('pairs', solver="mcsolve",
+                                                time_dependent=True),
+        ids=id_from_keys
+    )
+    def mc_keys(self, request):
+        return request.param

--- a/qutip/tests/solver/test_integrator.py
+++ b/qutip/tests/solver/test_integrator.py
@@ -1,62 +1,46 @@
-from qutip.solver.integrator import *
+from qutip.solver.integrator import (sesolve_integrators,
+                                     mesolve_integrators, mcsolve_integrators)
 from qutip.solver.options import SolverOptions
 from qutip.core import QobjEvo, liouvillian
-import qutip as qt
+import qutip
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
 
-def id_from_keys(keys):
-    if keys[1] == "":
-        return keys[0]
-    else:
-        return keys[0] + "_" + keys[1]
-
-
 class TestIntegratorCte():
     _analytical_se = lambda _, t: np.cos(t * np.pi)
-    se_system = QobjEvo(-1j * qt.sigmax() * np.pi)
+    se_system = qutip.QobjEvo(-1j * qutip.sigmax() * np.pi)
     _analytical_me = lambda _, t: 1 - np.exp(-t)
-    me_system = liouvillian(QobjEvo(qt.qeye(2)), c_ops=[qt.destroy(2)])
+    me_system = qutip.liouvillian(qutip.QobjEvo(qutip.qeye(2)),
+                                  c_ops=[qutip.destroy(2)])
 
-    @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="sesolve"),
-        ids=id_from_keys
-    )
-    def se_keys(self, request):
+    @pytest.fixture(params=list(sesolve_integrators.keys()))
+    def se_method(self, request):
         return request.param
 
-    @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="mesolve"),
-        ids=id_from_keys
-    )
-    def me_keys(self, request):
+    @pytest.fixture(params=list(mesolve_integrators.keys()))
+    def me_method(self, request):
         return request.param
 
-    @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="mcsolve"),
-        ids=id_from_keys
-    )
-    def mc_keys(self, request):
+    @pytest.fixture(params=list(mcsolve_integrators.keys()))
+    def mc_method(self, request):
         return request.param
 
-    def test_se_integration(self, se_keys):
-        method, rhs = se_keys
-        opt = SolverOptions(method=method, rhs=rhs)
-        evol = integrator_collection[method, rhs](self.se_system, opt)
-        state0 = qt.core.unstack_columns(qt.basis(6,0).data, (2, 3))
+    def test_se_integration(self, se_method):
+        opt = SolverOptions(method=se_method)
+        evol = sesolve_integrators[se_method](self.se_system, opt)
+        state0 = qutip.core.unstack_columns(qutip.basis(6,0).data, (2, 3))
         evol.set_state(0, state0)
         for t, state in evol.run(np.linspace(0, 2, 21)):
             assert_allclose(self._analytical_se(t),
                             state.to_array()[0, 0], atol=2e-5)
             assert state.shape == (2, 3)
 
-    def test_me_integration(self, me_keys):
-        method, rhs = me_keys
-        opt = SolverOptions(method=method, rhs=rhs)
-        evol = integrator_collection[method, rhs](self.me_system, opt)
-        state0 = qt.operator_to_vector(qt.fock_dm(2,1)).data
+    def test_me_integration(self, me_method):
+        opt = SolverOptions(method=me_method)
+        evol = mesolve_integrators[me_method](self.me_system, opt)
+        state0 = qutip.operator_to_vector(qutip.fock_dm(2,1)).data
         evol.set_state(0, state0)
         for t in np.linspace(0, 2, 21):
             t_, state = evol.integrate(t)
@@ -64,11 +48,10 @@ class TestIntegratorCte():
             assert_allclose(self._analytical_me(t),
                             state.to_array()[0, 0], atol=2e-5)
 
-    def test_mc_integration(self, mc_keys):
-        method, rhs = mc_keys
-        opt = SolverOptions(method=method, rhs=rhs)
-        evol = integrator_collection[method, rhs](self.se_system, opt)
-        state = qt.basis(2,0).data
+    def test_mc_integration(self, mc_method):
+        opt = SolverOptions(method=mc_method)
+        evol = mcsolve_integrators[mc_method](self.se_system, opt)
+        state = qutip.basis(2,0).data
         evol.set_state(0, state)
         t = 0
         for i in range(1, 21):
@@ -90,31 +73,30 @@ class TestIntegratorCte():
 
 class TestIntegrator(TestIntegratorCte):
     _analytical_se = lambda _, t: np.cos(t**2/2 * np.pi)
-    se_system = QobjEvo([-1j * qt.sigmax() * np.pi, "t"])
+    se_system = qutip.QobjEvo([-1j * qutip.sigmax() * np.pi, "t"])
     _analytical_me = lambda _, t: 1 - np.exp(-(t**3) / 3)
-    me_system = liouvillian(QobjEvo(qt.qeye(2)),
-                            c_ops=[QobjEvo([qt.destroy(2), 't'])])
+    me_system = qutip.liouvillian(
+        qutip.QobjEvo(qutip.qeye(2)),
+        c_ops=[qutip.QobjEvo([qutip.destroy(2), 't'])]
+    )
 
     @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="sesolve",
-                                                time_dependent=True),
-        ids=id_from_keys
+        params=[key for key, integrator in sesolve_integrators.items()
+                if integrator.support_time_dependant]
     )
     def se_keys(self, request):
         return request.param
 
     @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="mesolve",
-                                                time_dependent=True),
-        ids=id_from_keys
+        params=[key for key, integrator in mesolve_integrators.items()
+                if integrator.support_time_dependant]
     )
     def me_keys(self, request):
         return request.param
 
     @pytest.fixture(
-        params=integrator_collection._list_keys('pairs', solver="mcsolve",
-                                                time_dependent=True),
-        ids=id_from_keys
+        params=[key for key, integrator in mcsolve_integrators.items()
+                if integrator.support_time_dependant]
     )
     def mc_keys(self, request):
         return request.param


### PR DESCRIPTION
Introduce a common ODE integrator interface for qutip's solver.

Presently qutip's solver use scipy.integratre.ode's zvode ODE solver, which support adams and bdf methods.
These are great method in most case, but not always optimal.
This PR introduce, a common ODE interface Integrator and add support for 2 new scipy ODE solver: lsoda and dop853.